### PR TITLE
Fixed typo, fixed, warning, improved CSS

### DIFF
--- a/Splitdown.php
+++ b/Splitdown.php
@@ -89,8 +89,8 @@ class Splitdown {
 
 
 	public static function save( $post_id ){
-		$html = $_POST[ 'splitdown-markdown' ];
-		$markdown = $_POST[ 'content' ];
+		$html		= $_POST ? $_POST[ 'splitdown-markdown' ]	: '';
+		$markdown	= $_POST ? $_POST[ 'content' ]				: '';
 
 		update_post_meta( $post_id, '_splitdown_markdown', $markdown );
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,78 +1,110 @@
 html { height: 100%; }
 body { min-height: 100%; }
 
+.splitdown-editor,
+.splitdown-preview {
+	background-color: #fff;
+	border-radius: 0;
+	-webkit-box-sizing:	border-box;
+	-moz-box-sizing:	border-box;
+	box-sizing:			border-box;
+	height: 100%;
+	width: 100%;
+}
+
 .splitdown-editor {
-    width:100%;
-    min-height: 500px;
-    background-color: #FAFAFA;
-    margin-top:3px !important;
-    height:100%;
-    border-radius: 0px;
+	min-height: 500px;
 }
 
 .splitdown-preview {
-    height: 500px;
-    width:100%;
-    margin-top:3px !important;
-    overflow-y: scroll;
-    background-color: #fff;
+	background: #fefefe;
+	font-size: 13px;
+	height: 500px;
+	line-height: 150%;
+	overflow-y: scroll;
+	padding: 0 10px;
 }
 
 .splitdown-wrapper {
-    border-top:#edece4 1px solid;
-    margin-top: 30px;
-    width:100%;
-    height:100%;
+	background: transparent;
+	margin-top: 30px;
+	width: 100%;
+	height: 100%;
+}
+
+.splitdown-mirror-left,
+.splitdown-mirror-right {
+	background: #fff;
+	border: 1px solid #ddd;
+	-webkit-box-sizing:	border-box;
+	-moz-box-sizing:	border-box;
+	box-sizing:			border-box;
+	float: left;
+	margin: 0;
+	width: 49.5%;
 }
 
 .splitdown-mirror-left {
-    border-right:#edece4 1px solid;
-    min-height: 500px;
-    height:100%;
-    width:50%;
-    float:left;
-    margin-top: 5px;
+	min-height: 500px;
+	height: 100%;
+	margin: 0 1% 0 0;
 }
 
 .splitdown-mirror-right {
-    min-height: 500px;
-    height: 100%;
-    float:right;
-    width:49.9%;
-    margin-top: 5px;
+	min-height: 500px;
+}
+
+.splitdown-wrapper .wp-editor-area,
+.splitdown-wrapper textarea:focus {
+	border: 0;
+	margin: 0;
+	-webkit-box-shadow: none;
+	box-shadow:			none;
+}
+
+.splitdown-mirror-toolbar {
+	background-color: #f1f1f1;
+	border-bottom: 1px solid #edece4;
+	font-size: 13px;
+	line-height: 30px;
+	overflow: hidden;
+	padding: 4px 10px;
 }
 
 .splitdown-label {
-    color: #999999;
-    margin-left: 5px;
+	color: #999;
+	display: inline-block;
+	line-height: 26px;
+	vertical-align: baseline;
 }
 
 .splitdown-button {
-    background-color: #C5C5C5;
-    border-radius: 50px;
-    float: right;
-    margin-right: 5px;
-    width: 16px;
-    height: 16px;
-    text-align: center;
-    vertical-align: middle;
-    color: #ffffff;
-    font-weight: bold;
-    cursor: pointer;
-    text-decoration: none;
+	background-color: #c5c5c5;
+	border-radius: 26px;
+	color: #fff;
+	cursor: pointer;
+	float: right;
+	font-weight: bold;
+	height: 28px;
+	margin-right: 5px;
+	line-height: 28px;
+	text-align: center;
+	text-decoration: none;
+	vertical-align: top;
+	width: 28px;
 }
 
-.splitdown-button:visited, .splitdown-button:visited{
-    color: #ffffff;
-    text-decoration: none;
+.splitdown-button:hover,
+.splitdown-button:visited {
+	color: #fff;
+	text-decoration: none;
 }
 
-:fullscreen .splitdown-mirror-left, :-webkit-full-screen .splitdown-mirror-left, :-moz-full-screen .splitdown-mirror-left {
-    border-right:#000000 2px solid !important;
-
+.splitdown-button:hover {
+	background-color: #a5a5a5;
 }
 
-.splitdown-media-button {
-    float: right;
-    margin-right: 8px !important;
+.wp-core-ui .button.splitdown-media-button {
+	float: right;
+	margin-right: 8px;
 }

--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,23 @@
 #Splitdown
-## A Ghost like Markdown Editor replacement for Wordpress
+## A Markdown editor replacement for WordPress
 
-### How to install
-1. Clone the plugin to your wp-contents/plugins directory.
-2. You need to run ```git submodule init``` and ```git submodule update``` to pull showdown.js and html2markdown
-3. In your WP Dashboard go to ```Settings``` and than ```Writing```, scroll down to the Splitdown section and select on which post types you wish to use Splitdown on.
+### Installation
+1. Clone the plugin to your plugins directory, usually located at wp-contents/plugins.
+2. You need to run ```git submodule init``` and ```git submodule update``` to pull showdown.js and html2markdown.
+3. In your WP Dashboard go to ```Settings``` and than ```Writing```, scroll down to the Splitdown section and select which post types you wish to use Splitdown on.
 4. Enjoy
 
-### Note:
+### Other Notes
 I implemented an experimental version of the WordPress Media Manager. At the moment it does not work in distraction free mode.
 Since Markdown doesn't support css classes for elements, I need to write a showdown extension to fix this, so images can be displayed properly.
-As always this may take some time to implement, because I work alone in my spare time on this :) If you want to help, just
-fork this project and submit a pull request with your changes.
+As always this may take some time to implement, because I work alone in my spare time on this. :)
+If you want to help, please feel free to fork this project and submit a pull request with your changes.
 
-**If you find a bug or have a suggestion leave a ticket at https://github.com/Necrotex/Splitdown/issues.**
+### Contributions
+If you find a bug or have a suggestion, please leave a ticket at https://github.com/Necrotex/Splitdown/issues.
+
+### Support
+If you need support, please contact a WordPress expert. Issues are not for support questions.
 
 ### Javascript libraries used:
 + [showdown](https://github.com/coreyti/showdown)

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -1,14 +1,18 @@
 <div class="splitdown-wrapper" id="splitdown-wrapper">
-    <div class="splitdown-mirror-left">
-        <span class="splitdown-label">Markdown</span>
-        <a href="http://daringfireball.net/projects/markdown/syntax" target="_blank" title="Markdown help" class="splitdown-button">?</a>
-        <a href="#" id="splitdown-dmode" title="Distraction free mode" class="splitdown-button">D</a>
-        <a href="#" id="insert-media-button" class="button insert-media add_media splitdown-media-button" data-editor="content" title="Add Media"><span class="wp-media-buttons-icon"></span> Add Media</a>
-        <textarea class="wp-editor-area splitdown-editor" name="content" id="content" aria-hidden="true">{:markdown}</textarea>
-    </div>
-    <div class="splitdown-mirror-right">
-        <span class="splitdown-label">Preview</span>
-        <div class="splitdown-preview" id="splitdown-preview">{:html}</div>
-        <input type="hidden" name="splitdown-markdown" id="splitdown-markdown" />
-    </div>
+	<div class="splitdown-mirror-left">
+		<div class="splitdown-mirror-toolbar">
+			<span class="splitdown-label">Markdown</span>
+			<a href="http://daringfireball.net/projects/markdown/syntax" target="_blank" title="Markdown help" class="splitdown-button">?</a>
+			<a href="#" id="splitdown-dmode" title="Distraction free mode" class="splitdown-button">D</a>
+			<a href="#" id="insert-media-button" class="button insert-media add_media splitdown-media-button" data-editor="content" title="Add Media"><span class="wp-media-buttons-icon"></span> Add Media</a>
+		</div>
+		<textarea class="wp-editor-area splitdown-editor" name="content" id="content" aria-hidden="true">{:markdown}</textarea>
+	</div>
+	<div class="splitdown-mirror-right">
+		<div class="splitdown-mirror-toolbar">
+			<span class="splitdown-label">Preview</span>
+		</div>
+		<div class="splitdown-preview" id="splitdown-preview">{:html}</div>
+		<input type="hidden" name="splitdown-markdown" id="splitdown-markdown" />
+	</div>
 </div>


### PR DESCRIPTION
- Readme: fixed Wordpress into WordPress (capital P). 
- Readme: Removed reference to Ghost – dunno if that’s acceptable, but I thought Markdown with preview has existed before Ghost, so why cross-reference it in documentation?
- Fixed a warning thrown when a new post was yet unsaved and therefore `$_POST` was empty.
- Various improvements on UI in style.css.
