### PR TITLE
Fix some Warnings

### DIFF
--- a/Splitdown.php
+++ b/Splitdown.php
@@ -41,9 +41,13 @@ class Splitdown {
 		wp_enqueue_script( 'markdown-parser', plugins_url( '/js/html2markdown/markdown_dom_parser.js', __FILE__ ) );
 		wp_enqueue_script( 'markdown-renderer', plugins_url( '/js/html2markdown/html2markdown.js', __FILE__ ) );
 
-		foreach( $extensions as $extension ){
-			wp_enqueue_script( "showdown-{$extension}", plugins_url( "/js/showdown/compressed/extensions/{$extension}", __FILE__ ) );
-		}
+        if( is_array( $extensions ) ){
+
+		    foreach( $extensions as $extension ){
+		    	wp_enqueue_script( "showdown-{$extension}", plugins_url( "/js/showdown/compressed/extensions/{$extension}", __FILE__ ) );
+		    }
+        
+        }
 
 		wp_enqueue_script( 'splitdown', plugins_url( '/js/splitdown.js', __FILE__ ), array( 'jquery' ) );
 
@@ -179,6 +183,9 @@ class Splitdown {
 	public static function options_field_showdown_extensions(){
 		$current = get_option( 'splitdown_extensions', array() );
         $extensions = static::_get_showdown_extensions();
+
+        if( empty( $current ) )
+            $current = array();
 
         $out = "";
 


### PR DESCRIPTION
On first aktivation user gets some Warning about the extensions. The first is on line 44  must be an array but it is nothing. The second is on 180 thats the same must be a array but is nothing. This will be fixed with this commit.
