### PR TITLE
Multiple bug fixes

### DIFF
--- a/Splitdown.php
+++ b/Splitdown.php
@@ -24,43 +24,38 @@ class Splitdown {
 
 
 	public function __construct(){
-		add_action( 'init',						array( __CLASS__, 'remove_editor' ), 0, 10 );
-		add_action( 'edit_form_after_editor',	array( __CLASS__, 'load_editor' ), 0, 11 );
+		add_action( 'init',						array( $this, 'remove_editor' ), 0, 10 );
+		add_action( 'edit_form_after_editor',	array( $this, 'load_editor' ), 0, 11 );
 		add_action( 'admin_menu',				array( $this, 'enqueue_scripts' ) );
-		add_action( 'admin_menu',				array( __CLASS__, 'load_style' ) );
-		add_action( 'save_post',				array( __CLASS__, 'save' ) );
-		add_action( 'edit_post',				array( __CLASS__, 'save' ) );
-		add_action( 'admin_init',				array( __CLASS__, 'add_options' ) );
+		add_action( 'admin_menu',				array( $this, 'load_style' ) );
+		add_action( 'save_post',				array( $this, 'save' ) );
+		add_action( 'edit_post',				array( $this, 'save' ) );
+		add_action( 'admin_init',				array( $this, 'add_options' ) );
 	}
 
 
 	public function enqueue_scripts(){
 
 		// Only enqueue scripts on editor pages
-		global $post;
-		if ($post) {
+		$extensions = get_option( 'splitdown_extensions', array() );
 
-			$extensions = get_option( 'splitdown_extensions', array() );
+		wp_enqueue_script( 'showdown', plugins_url( '/js/showdown/compressed/showdown.js', __FILE__ ), array(), '0.1', true );
+		wp_enqueue_script( 'markdown-parser', plugins_url( '/js/html2markdown/markdown_dom_parser.js', __FILE__ ) );
+		wp_enqueue_script( 'markdown-renderer', plugins_url( '/js/html2markdown/html2markdown.js', __FILE__ ) );
 
-			wp_enqueue_script( 'showdown', plugins_url( '/js/showdown/compressed/showdown.js', __FILE__ ), array(), '0.1', true );
-			wp_enqueue_script( 'markdown-parser', plugins_url( '/js/html2markdown/markdown_dom_parser.js', __FILE__ ) );
-			wp_enqueue_script( 'markdown-renderer', plugins_url( '/js/html2markdown/html2markdown.js', __FILE__ ) );
+    if( is_array( $extensions ) ){
 
-      if( is_array( $extensions ) ){
+    foreach( $extensions as $extension ){
+    	wp_enqueue_script( "showdown-{$extension}", plugins_url( "/js/showdown/compressed/extensions/{$extension}", __FILE__ ) );
+    }
+    
+    }
 
-	    foreach( $extensions as $extension ){
-	    	wp_enqueue_script( "showdown-{$extension}", plugins_url( "/js/showdown/compressed/extensions/{$extension}", __FILE__ ) );
-	    }
-      
-      }
+		wp_enqueue_script( 'splitdown', plugins_url( '/js/splitdown.js', __FILE__ ), array( 'jquery' ) );
 
-			wp_enqueue_script( 'splitdown', plugins_url( '/js/splitdown.js', __FILE__ ), array( 'jquery' ) );
+    // Need for distraction free mode
+    wp_enqueue_script('screenfull', '//cdnjs.cloudflare.com/ajax/libs/screenfull.js/1.0.4/screenfull.min.js', array(), '3', true);
 
-	    // Need for distraction free mode
-	    wp_enqueue_script('screenfull', '//cdnjs.cloudflare.com/ajax/libs/screenfull.js/1.0.4/screenfull.min.js', array(), '3', true);
-
-
-    } 
 
 	}
 
@@ -198,12 +193,12 @@ class Splitdown {
 
 	public static function options_field_showdown_extensions(){
 		$current = get_option( 'splitdown_extensions', array() );
-        $extensions = static::_get_showdown_extensions();
+    $extensions = static::_get_showdown_extensions();
 
-        if( empty( $current ) )
-            $current = array();
+    if( empty( $current ) )
+        $current = array();
 
-        $out = "";
+    $out = "";
 
 		foreach( $extensions as $extension ){
 			$vals = array(

--- a/Splitdown.php
+++ b/Splitdown.php
@@ -26,7 +26,7 @@ class Splitdown {
 	public function __construct(){
 		add_action( 'init',						array( __CLASS__, 'remove_editor' ), 0, 10 );
 		add_action( 'edit_form_after_editor',	array( __CLASS__, 'load_editor' ), 0, 11 );
-		add_action( 'admin_menu',				array( __CLASS__, 'enqueue_scripts' ) );
+		add_action( 'admin_menu',				array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_menu',				array( __CLASS__, 'load_style' ) );
 		add_action( 'save_post',				array( __CLASS__, 'save' ) );
 		add_action( 'edit_post',				array( __CLASS__, 'save' ) );

--- a/Splitdown.php
+++ b/Splitdown.php
@@ -93,7 +93,13 @@ class Splitdown {
 
 
 	public static function save( $post_id ){
-		$html		= $_POST ? $_POST[ 'splitdown-markdown' ]	: '';
+
+		if ($_POST && isset($_POST["splitdown-markdown"])) {
+			$html = $_POST[ 'splitdown-markdown' ];
+		} else {
+			$html = "";
+		}
+
 		$markdown	= $_POST ? $_POST[ 'content' ]				: '';
 
 		update_post_meta( $post_id, '_splitdown_markdown', $markdown );

--- a/Splitdown.php
+++ b/Splitdown.php
@@ -35,26 +35,32 @@ class Splitdown {
 
 
 	public function enqueue_scripts(){
-		$extensions = get_option( 'splitdown_extensions', array() );
 
-		wp_enqueue_script( 'showdown', plugins_url( '/js/showdown/compressed/showdown.js', __FILE__ ), array(), '0.1', true );
-		wp_enqueue_script( 'markdown-parser', plugins_url( '/js/html2markdown/markdown_dom_parser.js', __FILE__ ) );
-		wp_enqueue_script( 'markdown-renderer', plugins_url( '/js/html2markdown/html2markdown.js', __FILE__ ) );
+		// Only enqueue scripts on editor pages
+		global $post;
+		if ($post) {
 
-        if( is_array( $extensions ) ){
+			$extensions = get_option( 'splitdown_extensions', array() );
 
-		    foreach( $extensions as $extension ){
-		    	wp_enqueue_script( "showdown-{$extension}", plugins_url( "/js/showdown/compressed/extensions/{$extension}", __FILE__ ) );
-		    }
-        
-        }
+			wp_enqueue_script( 'showdown', plugins_url( '/js/showdown/compressed/showdown.js', __FILE__ ), array(), '0.1', true );
+			wp_enqueue_script( 'markdown-parser', plugins_url( '/js/html2markdown/markdown_dom_parser.js', __FILE__ ) );
+			wp_enqueue_script( 'markdown-renderer', plugins_url( '/js/html2markdown/html2markdown.js', __FILE__ ) );
 
-		wp_enqueue_script( 'splitdown', plugins_url( '/js/splitdown.js', __FILE__ ), array( 'jquery' ) );
+      if( is_array( $extensions ) ){
 
-        // Need for distraction free mode
-        wp_enqueue_script('screenfull', '//cdnjs.cloudflare.com/ajax/libs/screenfull.js/1.0.4/screenfull.min.js', array(), '3', true);
+	    foreach( $extensions as $extension ){
+	    	wp_enqueue_script( "showdown-{$extension}", plugins_url( "/js/showdown/compressed/extensions/{$extension}", __FILE__ ) );
+	    }
+      
+      }
+
+			wp_enqueue_script( 'splitdown', plugins_url( '/js/splitdown.js', __FILE__ ), array( 'jquery' ) );
+
+	    // Need for distraction free mode
+	    wp_enqueue_script('screenfull', '//cdnjs.cloudflare.com/ajax/libs/screenfull.js/1.0.4/screenfull.min.js', array(), '3', true);
 
 
+    } 
 
 	}
 

--- a/Splitdown.php
+++ b/Splitdown.php
@@ -100,8 +100,12 @@ class Splitdown {
 			$html = "";
 		}
 
-		$markdown	= $_POST ? $_POST[ 'content' ]				: '';
-
+		if ($_POST && isset($_POST["content"])) {
+			$markdown	= $_POST[ 'content' ];
+		} else {
+			$markdown = "";
+		}
+		
 		update_post_meta( $post_id, '_splitdown_markdown', $markdown );
 
 		//remove actions to avoid endless loop

--- a/css/style.css
+++ b/css/style.css
@@ -30,6 +30,8 @@ body { min-height: 100%; }
 	margin-top: 30px;
 	width: 100%;
 	height: 100%;
+	overflow: auto;
+	margin-bottom: 20px;
 }
 
 .splitdown-mirror-left,

--- a/css/style.css
+++ b/css/style.css
@@ -26,7 +26,6 @@ body { min-height: 100%; }
 }
 
 .splitdown-wrapper {
-	background: transparent;
 	margin-top: 30px;
 	width: 100%;
 	height: 100%;

--- a/js/splitdown.js
+++ b/js/splitdown.js
@@ -2,15 +2,20 @@ var Splitdown;
 
 Splitdown = {
     source: '',
-    desination: '',
+    destination: '',
     converter: '',
 
     init: function () {
         Splitdown.source = jQuery( '#content' );
-        Splitdown.desination = jQuery( '#splitdown-preview' );
+        Splitdown.destination = jQuery( '#splitdown-preview' );
+
+        // Check to see if the source and destination exist
+        if (!Splitdown.source.length || !Splitdown.destination.length) {
+            return;
+        }
 
         Splitdown.converter = new Showdown.converter();
-
+ 
         this.source.on( 'keyup', this.update );
 
         jQuery( '#splitdown-dmode').on( 'click', this.dmode );
@@ -18,8 +23,8 @@ Splitdown = {
         jQuery(document).on(screenfull.raw.fullscreenchange, this.dmodeChange );
 
         //only convert html to markdown when there is a preview but no markdown
-        if( this.source.text().length == 0 && this.desination.html() != 0 ){
-             this.source.val( html2markdown( this.desination.html() ) );
+        if( this.source.text().length == 0 && this.destination.html() != 0 ){
+             this.source.val( html2markdown( this.destination.html() ) );
         }
 
         jQuery(document).ajaxSuccess( this.ajaxIntercept );
@@ -27,7 +32,7 @@ Splitdown = {
         // Update at the start to generate the HTML (otherwise when we save after
         // no changes, the_content() will be blank!)
         this.update();
-        
+
     },
 
     ajaxIntercept: function( event, xhr, settings){
@@ -56,13 +61,13 @@ Splitdown = {
     },
 
     update: function () {
-        Splitdown.desination.html(
+        Splitdown.destination.html(
             Splitdown.converter.makeHtml(
                 Splitdown.source.val()
             )
         );
 
-        jQuery( '#splitdown-markdown').val( Splitdown.desination.html() );
+        jQuery( '#splitdown-markdown').val( Splitdown.destination.html() );
     },
 
     dmode: function() {

--- a/js/splitdown.js
+++ b/js/splitdown.js
@@ -23,6 +23,11 @@ Splitdown = {
         }
 
         jQuery(document).ajaxSuccess( this.ajaxIntercept );
+
+        // Update at the start to generate the HTML (otherwise when we save after
+        // no changes, the_content() will be blank!)
+        this.update();
+        
     },
 
     ajaxIntercept: function( event, xhr, settings){


### PR DESCRIPTION
Hi there, I've just fixed a bunch of bugs, haven't added any new functionality. There's a couple of cases where I changed around the code formatting too.
- Now reference `$this` rather than `__CLASS__` - was causing PHP notices in some cases
- Splitdown scripts now only load on editing post pages, not all pages (was breaking Appearance > Menus)
- Handles blank `$_POST` values on save
- Has margin below editing wrapper so following widgets aren't touching
- Fixed spelling error for `destination` in JS
- Updates markdown at start to prevent blank posts being saved (the content that's previewed is the one that's saved)
